### PR TITLE
Change reference to 'schema.yml' file

### DIFF
--- a/dbt_coding_conventions.md
+++ b/dbt_coding_conventions.md
@@ -53,7 +53,7 @@ Our models (typically) fit into three main categories: staging, marts, base/inte
 
 ## Testing
 
-- Every subdirectory should contain a `schema.yml` file, in which each model in the subdirectory is tested.
+- Every subdirectory should contain a `stg_<source>.yml` file, in which each model in the subdirectory is tested.
 - At a minimum, unique and not_null tests should be applied to the primary key of each model.
 
 ## Naming and field conventions


### PR DESCRIPTION
Please consider changing the reference to 'schema.yml' file to something like 'stg_<source>.yml' in order to bring this document to the current convention. For reference here is the reference article that talks about not using 'schema.yml':
https://docs.getdbt.com/reference/declaring-properties#schemayml-files
Also, the 'How we structure our dbt projects' discourse post available here 
https://discourse.getdbt.com/t/how-we-structure-our-dbt-projects/355

This will decerease the potential for confusion of new users (like me). Thanks!