### PR TITLE
Fix: Removed line about using condition

### DIFF
--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -110,7 +110,6 @@ select * from filtered_events
 - Fields should be stated before aggregates / window functions
 - Aggregations should be executed as early as possible before joining to another table.
 - Ordering and grouping by a number (eg. group by 1, 2) is preferred over listing the column names (see [this rant](https://blog.getdbt.com/write-better-sql-a-defense-of-group-by-1/) for why). Note that if you are grouping by more than a few columns, it may be worth revisiting your model design.
-- Specify join keys - do not use `using`. Certain warehouses have inconsistencies in `using` results (specifically Snowflake).
 - Prefer `union all` to `union` [*](http://docs.aws.amazon.com/redshift/latest/dg/c_example_unionall_query.html)
 - Avoid table aliases in join conditions (especially initialisms) – it's harder to understand what the table called "c" is compared to "customers".
 - If joining two or more tables, _always_ prefix your column names with the table alias. If only selecting from one table, prefixes are not needed.


### PR DESCRIPTION
Our style guide had a line in it about not using the `using` logic for joins. We've determined that this is no longer the case and can (and should) be used.