### PR TITLE
Add Metrics Style Subsection

### DIFF
--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -240,6 +240,47 @@ models:
               field: id
 ```
 
+## Metrics style guide
+
+* dbt Metrics definitions are a special kind of YAML file, with additional conventions.
+* Metrics names must begin with a letter, cannot contain whitespace, and should be all lowercase.
+* Tags and/or Meta properties should be used to organize metrics at the business function level.
+* Meta properties should be used to track metric definition ownership.
+* The [minimum required properties](https://docs.getdbt.com/docs/building-a-dbt-project/metrics#available-properties) must be present in the metric definition.
+* For up-to-date information on metrics, please see the [metrics docs on defining a metrics](https://docs.getdbt.com/docs/building-a-dbt-project/metrics#defining-a-metric) or the [dbt-labs/metrics README](https://github.com/dbt-labs/dbt_metrics#readme)
+
+### Example Metric YAML
+```yaml
+version: 2
+
+metrics:
+  - name: weekly_active_projects
+    label: Cumulative Weekly Active Projects
+    model: ref('fct_dbt_project_activity')
+    description: >
+      """The running total of dbt Projects with at least one
+      invocation in the last trailing 7 days for any given day."""
+    tags: ['Company Metric']
+
+    type: count_distinct
+    sql: project_id
+
+    timestamp: date_day
+    time_grains: [day]
+
+    dimensions:
+      - adapter
+
+    filters:
+      - field: t7d_active
+        operator: 'is'
+        value: true
+
+    meta:
+      metric_level: 'Company'
+      owner(s): 'Jane Doe'
+```
+
 
 ## Jinja style guide
 

--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -10,25 +10,35 @@ Our models (typically) fit into three main categories: staging, marts, base/inte
     |       ├── intermediate
     |       |   ├── intermediate.yml
     |       |   ├── customers__unioned.sql
-    |       |   ├── customers__grouped.sql
-    |       └── core.yml
-    |       └── core.docs
-    |       └── dim_customers.sql
+    |       |   └── customers__grouped.sql
+    |       ├── core.yml
+    |       ├── core.docs
+    |       ├── dim_customers.sql
     |       └── fct_orders.sql
-    └── staging
-        └── stripe
-            ├── base
-            |   ├── base__stripe_invoices.sql
-            ├── src_stripe.yml
-            ├── src_stripe.docs
-            ├── stg_stripe.yml
-            ├── stg_stripe__customers.sql
-            └── stg_stripe__invoices.sql
+    ├── staging
+    |   └── stripe
+    |       ├── base
+    |       |   └── base__stripe_invoices.sql
+    |       ├── src_stripe.yml
+    |       ├── src_stripe.docs
+    |       ├── stg_stripe.yml
+    |       ├── stg_stripe__customers.sql
+    |       └── stg_stripe__invoices.sql
+    └── metrics
+        ├── projects
+        |   ├── active_projects.yml
+        ├── accounts
+        |   ├── active_cloud_accounts.yml
+        └── users
+            ├── base__net_promoter_score.yml
+            └── net_promoter_score.yml
+
 ```
 - All objects should be plural, such as: `stg_stripe__invoices`
 - Base tables are prefixed with `base__`, such as: `base__<source>_<object>`
 - Intermediate tables should end with a past tense verb indicating the action performed on the object, such as: `customers__unioned`
 - Marts are categorized between fact (immutable, verbs) and dimensions (mutable, nouns) with a prefix that indicates either, such as: `fct_orders` or `dim_customers`
+- Metrics are categorized by entity (object grain that the metrics occurs), and filenames directly correspond to metrics. Filenames are prefixed with `base__` only if they are pre-calculated inputs to derived metrics in other files.
 
 ## Model configuration
 

--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -247,7 +247,8 @@ models:
 * Tags and/or Meta properties should be used to organize metrics at the business function level.
 * Meta properties should be used to track metric definition ownership.
 * The [minimum required properties](https://docs.getdbt.com/docs/building-a-dbt-project/metrics#available-properties) must be present in the metric definition.
-* For up-to-date information on metrics, please see the [metrics docs on defining a metrics](https://docs.getdbt.com/docs/building-a-dbt-project/metrics#defining-a-metric) or the [dbt-labs/metrics README](https://github.com/dbt-labs/dbt_metrics#readme)
+* For up-to-date information on metrics, please see the [metrics docs on defining a metric](https://docs.getdbt.com/docs/building-a-dbt-project/metrics#defining-a-metric) or the [dbt-labs/metrics README](https://github.com/dbt-labs/dbt_metrics#readme)
+
 
 ### Example Metric YAML
 ```yaml

--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -259,8 +259,8 @@ metrics:
     label: Cumulative Weekly Active Projects
     model: ref('fct_dbt_project_activity')
     description: >
-      """The running total of dbt Projects with at least one
-      invocation in the last trailing 7 days for any given day."""
+      'The running total of dbt Projects with at least one
+      invocation in the last trailing 7 days for any given day.'
     tags: ['Company Metric']
 
     type: count_distinct

--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -251,7 +251,7 @@ Because of the wide socialization of these docs and downstream usage in the BI l
 
 * Metrics names must begin with a letter, cannot contain whitespace, and should be all lowercase.
 * The [minimum required properties](https://docs.getdbt.com/docs/building-a-dbt-project/metrics#available-properties) must be present in the metric definition.
-* Tags and/or Meta properties should be used to organize metrics at the business function level.
+* Tags and/or Meta properties should match the categories above and be used to organize metrics at the category or business function level.
 * Meta properties should be used to track metric definition ownership.
 * For up-to-date information on metrics, please see the [metrics docs on defining a metric](https://docs.getdbt.com/docs/building-a-dbt-project/metrics#defining-a-metric) or the [dbt-labs/metrics README](https://github.com/dbt-labs/dbt_metrics#readme)
 

--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -241,7 +241,7 @@ models:
 ```
 
 ## Metrics style guide
-dbt Metrics will naturally fall into four broad categories:
+dbt Metrics fall into four broad categories:
 1. Company metrics
 2. Team KPIs
 3. OKRs
@@ -262,31 +262,71 @@ Because of the wide socialization of these docs and downstream usage in the BI l
 version: 2
 
 metrics:
-  - name: weekly_active_projects
-    label: Cumulative Weekly Active Projects
-    model: ref('fct_dbt_project_activity')
+  - name: base__total_nps_respondents_cloud
+    label: (Base) Total of NPS Respondents (Cloud)
+    model: ref('fct_customer_nps')
     description: >
-      'The running total of dbt Projects with at least one
-      invocation in the last trailing 7 days for any given day.'
+      'The count of users responding to NPS surveys in dbt Cloud.'
     tags: ['Company Metric']
 
-    type: count_distinct
-    sql: project_id
+    type: count
+    sql: unique_id
 
-    timestamp: date_day
-    time_grains: [day]
+    timestamp: created_at
+    time_grains: [day, month, quarter, year]
 
     dimensions:
-      - adapter
+      - feedback_source
 
     filters:
-      - field: t7d_active
-        operator: 'is'
-        value: true
+      - field: feedback_source
+        operator: '='
+        value: "'dbt_cloud_nps'"
 
     meta:
       metric_level: 'Company'
       owner(s): 'Jane Doe'
+
+
+  - name: base__count_nps_promoters_cloud
+    label: (Base) Count of NPS Promoters (Cloud)
+    model: ref('fct_customer_nps')
+    description: >
+      'The count of dbt Cloud respondents that fall into the promoters segment.'
+    tags: ['Company Metric']
+
+    type: count
+    sql: unique_id
+
+    timestamp: created_at
+    time_grains: [day, month, quarter, year]
+
+    filters:
+      - field: feedback_source
+        operator: '='
+        value: "'dbt_cloud_nps'"
+      - field: nps_category
+        operator: '='
+        value: "'promoter'"
+
+    meta:
+      metric_level: 'Company'
+      owner(s): 'Jane Doe'
+
+  - name: promoters_pct
+    label: Percent Promoters (Cloud)
+    description: 'The percent of dbt Cloud users in the promoters segment.'
+    tags: ['Company Metric']
+
+    type: expression
+    sql: "{{metric('count_nps_promoters_cloud')}} / {{metric('total_nps_respondents_cloud')}}" 
+
+    timestamp: created_at
+    time_grains: [day, month, quarter, year]
+
+    meta:
+      metric_level: 'Company'
+      owner(s): 'Andrew Tom'
 ```
 
 

--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -241,13 +241,20 @@ models:
 ```
 
 ## Metrics style guide
+dbt Metrics will naturally fall into four broad categories:
+1. Company metrics
+2. Team KPIs
+3. OKRs
+4. Specific metrics related to a product area, business unit, or business function that is not necessarily a team KPI, but important to track nonetheless.
 
-* dbt Metrics definitions are a special kind of YAML file, with additional conventions.
+Because of the wide socialization of these docs and downstream usage in the BI layer, consistency and clarity are _very_ important. Below are the general standards and examples of how we format and implement metrics at dbt Labs:
+
 * Metrics names must begin with a letter, cannot contain whitespace, and should be all lowercase.
+* The [minimum required properties](https://docs.getdbt.com/docs/building-a-dbt-project/metrics#available-properties) must be present in the metric definition.
 * Tags and/or Meta properties should be used to organize metrics at the business function level.
 * Meta properties should be used to track metric definition ownership.
-* The [minimum required properties](https://docs.getdbt.com/docs/building-a-dbt-project/metrics#available-properties) must be present in the metric definition.
 * For up-to-date information on metrics, please see the [metrics docs on defining a metric](https://docs.getdbt.com/docs/building-a-dbt-project/metrics#defining-a-metric) or the [dbt-labs/metrics README](https://github.com/dbt-labs/dbt_metrics#readme)
+
 
 
 ### Example Metric YAML


### PR DESCRIPTION
In anticipation of wider use of our internal projects Semantic Layer, we're aligning on organizational and style conventions for metric definitions yaml files. Metric definitions are all inclusive of our YAML style conventions. They will be organized by entity in the file structure, and should be grouped by business function using tags and meta properties.