### PR TITLE
Adding to values.md re: recognizing value

### DIFF
--- a/values.md
+++ b/values.md
@@ -30,6 +30,10 @@ We market our products and services by working with amazing humans, making them 
 
 While we believe that we are building something exceptional, that knowledge does not make us feel proud, it makes us feel humble. It imbues us with a deep sense of responsibility towards our clients, coworkers, and the community at large.
 
+### We value ourselves.
+
+We stand behind the products we have built and assign value to each of them according to the effort they represent and the resources needed to support them. This should apply to all of our products both on their own and in relation to one another. 
+
 ### We optimize for the long-term.
 
 While we pursue the mission with intense focus, we recognize that creating the change in the world that we wish to see will not happen overnight. We think, plan, and act for the long-term.


### PR DESCRIPTION
Pricing as a discussion point was always going to be a difficult conversation at dbt Labs. It can feel actively antithetical to some values (Profits are exhaust, Values are more important than success) and can make us concerned about culture creep generally. 

Nevertheless, it is both an overcorrection and unfair to our front-of-house team members to treat pricing as, at best, the third rail. Given that, it might benefit us as a company to treat pricing as another part of being a business, in that we must define our relationship with it rather than defining ourselves without it. 

This value would seek to capture the goals we have around pricing, namely creating a structure that:
- appropriately values our effort, particularly in the face of our open source solution remaining available. 
- aligns with the resources required to do our best work and support it beyond release. 
- respects our customers, with price tiering reflective of comparable feature tiering.
- allows our sales and business development teams to empower the business without being functionally isolated from our values.