### PR TITLE
long-term updates

### DIFF
--- a/values.md
+++ b/values.md
@@ -32,7 +32,7 @@ While we believe that we are building something exceptional, that knowledge does
 
 ### We optimize for the long-term.
 
-While we pursue the mission with intense focus, we recognize that creating the change in the world that we wish to see will not happen overnight. We think, plan, and act for the long-term.
+We recognize that creating the change in the world that we wish to see will not happen overnight. Earning the right to pursue this work over decades requires both long-term vision and near-term execution, both user love and commercial success.
 
 ### We work hard and go home.
 


### PR DESCRIPTION
This is another instance of “Tristan’s PJB” circa 2016. We do absolutely want to build a lasting company, we want to solve big problems, and we want to think long-term. But this text as written makes it feel that we *exclusively* care about long-term focus. The truth of the matter is that if we don’t execute in the short-term, we actually do not get the privilege to _exist_ in the long-term. That was not something that needed to be said in 2017 with a tiny little team—it was incredibly obvious that if we didn’t do any client work then we didn’t have any $$ to pay salaries and we all had to go look for other jobs. But our company is much bigger and more complex, and this focus on near-term execution needs to be called out more explicitly. 

So: just like the other changes I’m proposing, this is not actually a shift in how we’ve historically operated as a business. It’s always been true that we need to execute in the short term in order to earn the right to continue to exist. This change just makes that explicit.

Transmitting knowledge explicitly, rather than implicitly, is incredibly important as we grow the org ever-larger. We have to actually say exactly what we mean, and as previously written this text fails that test.