### PR TITLE
Replace call to surrogate_key with generate_surrogate_key in example code

### DIFF
--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -185,7 +185,7 @@ For more information about why we use so many CTEs, check out [this glossary ent
   -- Logical CTEs
   locations as (
       select
-          {{ dbt_utils.surrogate_key([
+          {{ dbt_utils.generate_surrogate_key([
               'regions.region_id',            
               'nations.nation_id'
           ]) }} as location_sk,


### PR DESCRIPTION
According to dbt-utils docs, surrogate_key has been replaced because it had a bug

https://github.com/dbt-labs/dbt-utils/blob/main/README.md#generate_surrogate_key-source