### PR TITLE
Please do not use `using`

### DIFF
--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -283,6 +283,8 @@ For more information about why we use so many CTEs, check out [this glossary ent
 
 - Be explicit about your join (i.e. write `inner join` instead of `join`). `left joins` are the most common, `right joins` often indicate that you should change which table you select `from` and which one you `join` to.
 
+- Avoid the `using` clause in joins, prefering instead to explicitly list the CTEs and associated join keys with an `on` clause.
+
 - Joins should list the left table first (i.e., the table you're joining data to)  
   Example:
   ```sql

--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -283,7 +283,7 @@ For more information about why we use so many CTEs, check out [this glossary ent
 
 - Be explicit about your join (i.e. write `inner join` instead of `join`). `left joins` are the most common, `right joins` often indicate that you should change which table you select `from` and which one you `join` to.
 
-- Avoid the `using` clause in joins, prefering instead to explicitly list the CTEs and associated join keys with an `on` clause.
+- Avoid the `using` clause in joins, preferring instead to explicitly list the CTEs and associated join keys with an `on` clause.
 
 - Joins should list the left table first (i.e., the table you're joining data to)  
   Example:


### PR DESCRIPTION
Add guidance to the style guide for writing explicit join instructions with an `on` clause instead of implicit join instructions with a `using` clause.

The data team has experienced drift in our internal project based on personal preferences and would like to add this rule to the style guide to use for reference when we request changes on a `using` clause.