### PR TITLE
Feature: update metric style for dbt v1.6

### DIFF
--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -584,7 +584,8 @@ semantic_models:
       Order fact table. This table is at the order grain with one row per order. 
     #The name of the dbt model and schema
     model: ref('orders')
-    #Entities. These usually corespond to keys in the table.
+    #Entities. These usually correspond to keys in the table.
+
     entities:
       - name: order_id
         type: primary

--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -658,4 +658,4 @@ metrics:
       denominator: transaction_amount
       filter: >   #  add optional constraint string. This applies to both the numerator and denominator
         {{ Dimension('customer__country') }} = 'MX'
-``````
+```


### PR DESCRIPTION
A quick revamp of the Metrics Conventions section of our style guide for dbt v1.6.

As best practices are still emerging for semantic layer usage, this revision is meant re-align dbt Semantic Layer style with our current state. This helps dbt contributors to align with the conventions we have in place. As we adopt or identify maintainable conventions at scale, **we will update this to be more opinionated.**

As resources for future discussion, there are practices as observed in the [getting started repo ](https://docs.getdbt.com/guides/best-practices/how-we-build-our-metrics/semantic-layer-7-conclusion) that we have yet to  adopt. Furthermore, there is light [discussion in our internal slack](https://dbt-labs.slack.com/archives/C04D0BH3RL6/p1691510340463379?thread_ts=1691418666.406769&cid=C04D0BH3RL6) around structure.

@paigeb has editorial privileges and co-ownership in this pull request.