### PR TITLE
hotfix: remove double link

### DIFF
--- a/dbt_style_guide.md
+++ b/dbt_style_guide.md
@@ -1,3 +1,3 @@
 ## 🚧 This page has moved!
 
-Historically this page housed the venerable, beloved, occassionally-controversial-to-leading-commas-enthusiasts dbt Labs Style Guide. We've updated and expanded that to a [new home on the dbt Developer Hub](https://docs.getdbt.com/guides/best-practices/how-we-style/0-how-we-style-our-dbt-projects)https://docs.getdbt.com/guides/best-practices/how-we-style/0-how-we-style-our-dbt-projects, with recommendations on how you can create and enforce a style guide at your organization.
+Historically this page housed the venerable, beloved, occassionally-controversial-to-leading-commas-enthusiasts dbt Labs Style Guide. We've updated and expanded that to a [new home on the dbt Developer Hub](https://docs.getdbt.com/guides/best-practices/how-we-style/0-how-we-style-our-dbt-projects), with recommendations on how you can create and enforce a style guide at your organization.


### PR DESCRIPTION
There were two links -- one hotlink + one URL. Removed the latter for ✨ aesthetics✨